### PR TITLE
Add span user events in the instrumented runtime

### DIFF
--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -79,4 +79,6 @@ DOMAIN_STATE(uint32_t, eventlog_startup_pid)
 DOMAIN_STATE(uintnat, eventlog_paused)
 DOMAIN_STATE(uintnat, eventlog_enabled)
 DOMAIN_STATE(FILE*, eventlog_out)
+DOMAIN_STATE(FILE*, ctf_metadata_file)
+DOMAIN_STATE(uint32_t, ctf_user_event_id)
 /* See eventlog.c */

--- a/runtime/caml/eventlog.h
+++ b/runtime/caml/eventlog.h
@@ -131,5 +131,3 @@ void caml_ev_flush(void);
 #endif /*CAML_INSTR*/
 
 #endif /*CAML_EVENTLOG_H*/
-
-#endif /*CAML_EVENTLOG_H*/

--- a/runtime/caml/eventlog.h
+++ b/runtime/caml/eventlog.h
@@ -22,7 +22,8 @@ typedef enum {
     EV_EXIT,
     EV_COUNTER,
     EV_ALLOC,
-    EV_FLUSH
+    EV_FLUSH,
+    MIN_AVAILABLE_EVENT_ID
 } ev_type;
 
 typedef enum {
@@ -56,8 +57,10 @@ typedef enum {
     EV_MINOR_COPY,
     EV_MINOR_UPDATE_WEAK,
     EV_MINOR_FINALIZED,
-    EV_EXPLICIT_GC_MAJOR_SLICE
-} ev_gc_phase;
+    EV_EXPLICIT_GC_MAJOR_SLICE,
+    EV_USER_BEGIN,
+    EV_USER_END
+} ev_span_type;
 
 typedef enum {
     EV_C_ALLOC_JUMP,
@@ -79,11 +82,6 @@ typedef enum {
     EV_C_REQUEST_MINOR_REALLOC_EPHE_REF_TABLE,
     EV_C_REQUEST_MINOR_REALLOC_CUSTOM_TABLE
 } ev_gc_counter;
-
-typedef enum {
-    EV_USER_BEGIN,
-    EV_USER_END
-} ev_user_type;
 
 #ifdef CAML_INSTR
 
@@ -110,8 +108,8 @@ typedef enum {
 
 void caml_eventlog_init(void);
 void caml_eventlog_disable(void);
-void caml_ev_begin(ev_gc_phase phase);
-void caml_ev_end(ev_gc_phase phase);
+void caml_ev_begin(ev_span_type span_type);
+void caml_ev_end(ev_span_type span_type);
 void caml_ev_counter(ev_gc_counter counter, uint64_t val);
 void caml_ev_alloc(uint64_t size);
 void caml_ev_alloc_flush(void);
@@ -131,5 +129,7 @@ void caml_ev_flush(void);
 #define CAML_EV_FLUSH() /**/
 
 #endif /*CAML_INSTR*/
+
+#endif /*CAML_EVENTLOG_H*/
 
 #endif /*CAML_EVENTLOG_H*/

--- a/runtime/caml/eventlog.h
+++ b/runtime/caml/eventlog.h
@@ -80,6 +80,11 @@ typedef enum {
     EV_C_REQUEST_MINOR_REALLOC_CUSTOM_TABLE
 } ev_gc_counter;
 
+typedef enum {
+    EV_USER_BEGIN,
+    EV_USER_END
+} ev_user_type;
+
 #ifdef CAML_INSTR
 
 #define CAML_EVENTLOG_DO(f) if (Caml_state->eventlog_enabled &&\

--- a/runtime/eventlog.c
+++ b/runtime/eventlog.c
@@ -44,7 +44,6 @@
 #define CTF_METADATA_MAGIC 0x75D11D57
 #define CTF_MAJOR_VERSION 1
 #define CTF_MINOR_VERSION 8
-#define MIN_AVAILABLE_EVENT_ID 5
 #define CTF_TRACE_UUID {0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa}
 
 /* The structs in this section are emitted structs, i.e. they
@@ -81,10 +80,237 @@ struct ctf_metadata_header {
   uint8_t  minor;
 };
 
-/* The fixed metadataa description for the GC events */
-const char_os *fixed_metadata = "/* CTF 1.8 */\n\ntypealias integer {size = 8;}  := uint8_t;\ntypealias integer {size = 16;} := uint16_t;\ntypealias integer {size = 32;} := uint32_t;\ntypealias integer {size = 64;} := uint64_t;\n\nclock {\n    name = tracing_clock;\n    freq = 1000000000; /* tick = 1 ns */\n};\n\ntypealias integer {\n    size = 64;\n    map = clock.tracing_clock.value;\n} := tracing_clock_int_t;\n\n\n/*\n\nMain trace description,\nmajor and minor refers to the CTF version being used.\n\nThe packet header must contain at the very least\na stream id and the CTF magic number.\nWe only use one stream for now, and CTF magic number is 0xc1fc1fc1.\n\nWe add an extra field ocaml_trace_version to enable simpler transition if we add\nor remove metrics in the future.\n\n*/\ntrace {\n    major = 1;\n    minor = 8;\n    uuid = \"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\";\n    byte_order = le;\n    packet.header := struct {\n        uint32_t magic; /* required: must contain CTF magic number */\n        uint16_t ocaml_trace_version; /* our own trace format versioning */\n        uint8_t uuid[16];\n        uint16_t stream_id; /* required, although we have only one. */\n    };\n};\n\n/*\n\nWe use only one stream at the moment.\nEach event payload must contain a header with a timestamp and a pid.\nThe id field refers to the various event kinds defined further down this file.\n\n*/\nstream {\n    id = 0;\n    event.header := struct { /* for each event */\n        tracing_clock_int_t timestamp;\n        uint32_t id;\n    };\n    packet.context := struct {\n        uint32_t pid;\n    };\n};\n\n/*\n\nThese enumerations are mostly following the instrumented runtime datapoints.\ngc_phase aims to track the entry and exit time of each of the following events\nduring collection.\n\n*/\nenum gc_phase : uint16_t {\n    \"compact/main\" = 0,\n    \"compact/recompact\",\n    \"explicit/gc_set\",\n    \"explicit/gc_stat\",\n    \"explicit/gc_minor\",\n    \"explicit/gc_major\",\n    \"explicit/gc_full_major\",\n    \"explicit/gc_compact\",\n    \"major\",\n    \"major/roots\",\n    \"major/sweep\",\n    \"major/mark/roots\",\n    \"major/mark/main\",\n    \"major/mark/final\",\n    \"major/mark\",\n    \"major/mark/global_roots_slice\",\n    \"major_roots/global\",\n    \"major_roots/dynamic_global\",\n    \"major_roots/local\",\n    \"major_roots/C\",\n    \"major_roots/finalised\",\n    \"major_roots/memprof\",\n    \"major_roots/hook\",\n    \"major/check_and_compact\",\n    \"minor\",\n    \"minor/local_roots\",\n    \"minor/ref_tables\",\n    \"minor/copy\",\n    \"minor/update_weak\",\n    \"minor/finalized\",\n    \"explicit/gc_major_slice\"\n};\n\n/*\n\nMiscellaneous GC counters\n\n*/\nenum gc_counter : uint16_t {\n    \"alloc_jump\",\n    \"force_minor/alloc_small\",\n    \"force_minor/make_vect\",\n    \"force_minor/set_minor_heap_size\",\n    \"force_minor/weak\",\n    \"force_minor/memprof\",\n    \"major/mark/slice/remain\",\n    \"major/mark/slice/fields\",\n    \"major/mark/slice/pointers\",\n    \"major/work/extra\",\n    \"major/work/mark\",\n    \"major/work/sweep\",\n    \"minor/promoted\",\n    \"request_major/alloc_shr\",\n    \"request_major/adjust_gc_speed\",\n    \"request_minor/realloc_ref_table\",\n    \"request_minor/realloc_ephe_ref_table\",\n    \"request_minor/realloc_custom_table\"\n};\n\n/*\n\nBlock allocation counters, per size buckets.\n\n*/\nenum alloc_bucket : uint8_t {\n  \"alloc 01\" = 1,\n  \"alloc 02\",\n  \"alloc 03\",\n  \"alloc 04\",\n  \"alloc 05\",\n  \"alloc 06\",\n  \"alloc 07\",\n  \"alloc 08\",\n  \"alloc 09\",\n  \"alloc 10-19\",\n  \"alloc 20-29\",\n  \"alloc 30-39\",\n  \"alloc 40-49\",\n  \"alloc 50-59\",\n  \"alloc 60-69\",\n  \"alloc 70-79\",\n  \"alloc 80-89\",\n  \"alloc 90-99\",\n  \"alloc large\"\n};\n\n/*\n\nEach event is comprised of the previously defined event.header\nand the fields defined here.\n\nAn entry event marks the start of a gc phase.\n\n*/\nevent {\n    id = 0;\n    name = \"entry\";\n    stream_id = 0;\n    fields := struct {\n        enum gc_phase phase;\n    };\n};\n\n/*\n\nexit counterparts to entry events\n\n*/\nevent {\n    id = 1;\n    name = \"exit\";\n    stream_id = 0;\n    fields := struct {\n        enum gc_phase phase;\n    };\n};\n\nevent {\n    id = 2;\n    name = \"counter\";\n    stream_id = 0;\n    fields := struct {\n        uint64_t count;\n        enum gc_counter kind;\n    };\n};\n\nevent {\n    id = 3;\n    name = \"alloc\";\n    stream_id = 0;\n    fields := struct {\n        uint64_t count;\n        enum alloc_bucket bucket;\n    };\n};\n\n/*\n Flush events are used to track the time spent by the tracing runtime flushing\n data to disk, useful to remove flushing overhead for other runtime mesurements\n in the trace.\n*/\nevent {\n     id = 4;\n     name = \"flush\";\n     stream_id = 0;\n     fields := struct {\n        uint64_t duration;\n     };\n};\n";
+/* The fixed metadata description for the GC events */
+const char_os *fixed_metadata = "/* CTF 1.8 */\n\n"
+  ""
+  "typealias integer {size = 8;}  := uint8_t;\n"
+  "typealias integer {size = 16;} := uint16_t;\n"
+  "typealias integer {size = 32;} := uint32_t;\n"
+  "typealias integer {size = 64;} := uint64_t;\n\n"
+  ""
+  "clock {\n"
+  "    name = tracing_clock;\n"
+  "    freq = 1000000000; /* tick = 1 ns */\n"
+  "};\n\n"
+  ""
+  "typealias integer {\n"
+  "    size = 64;\n"
+  "    map = clock.tracing_clock.value;\n"
+  "} := tracing_clock_int_t;\n\n\n"
+  ""
+  ""
+  "/*\n\n"
+  ""
+  "Main trace description,\n"
+  "major and minor refers to the CTF version being used.\n\n"
+  ""
+  "The packet header must contain at the very least\n"
+  "a stream id and the CTF magic number.\n"
+  "We only use one stream for now, and CTF magic number is 0xc1fc1fc1.\n\n"
+  ""
+  "We add an extra field ocaml_trace_version to enable simpler transition if we add\n"
+  "or remove metrics in the future.\n\n"
+  ""
+  "*/\n"
+  "trace {\n"
+  "    major = 1;\n"
+  "    minor = 8;\n"
+  "    uuid = \"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\";\n"
+  "    byte_order = le;\n"
+  "    packet.header := struct {\n"
+  "        uint32_t magic; /* required: must contain CTF magic number */\n"
+  "        uint16_t ocaml_trace_version; /* our own trace format versioning */\n"
+  "        uint8_t uuid[16];\n"
+  "        uint16_t stream_id; /* required, although we have only one. */\n"
+  "    };\n"
+  "};\n\n"
+  ""
+  "/*\n\n"
+  ""
+  "We use only one stream at the moment.\n"
+  "Each event payload must contain a header with a timestamp and a pid.\n"
+  "The id field refers to the various event kinds defined further down this file.\n\n"
+  ""
+  "*/\n"
+  "stream {\n"
+  "    id = 0;\n"
+  "    event.header := struct { /* for each event */\n"
+  "        tracing_clock_int_t timestamp;\n"
+  "        uint32_t id;\n"
+  "    };\n"
+  "    packet.context := struct {\n"
+  "        uint32_t pid;\n"
+  "    };\n"
+  "};\n\n"
+  ""
+  "/*\n\n"
+  ""
+  "These enumerations are mostly following the instrumented runtime datapoints.\n"
+  "gc_phase aims to track the entry and exit time of each of the following events\n"
+  "during collection.\n\n"
+  ""
+  "*/\n"
+  "enum gc_phase : uint16_t {\n"
+  "    \"compact/main\" = 0,\n"
+  "    \"compact/recompact\",\n"
+  "    \"explicit/gc_set\",\n"
+  "    \"explicit/gc_stat\",\n"
+  "    \"explicit/gc_minor\",\n"
+  "    \"explicit/gc_major\",\n"
+  "    \"explicit/gc_full_major\",\n"
+  "    \"explicit/gc_compact\",\n"
+  "    \"major\",\n"
+  "    \"major/roots\",\n"
+  "    \"major/sweep\",\n"
+  "    \"major/mark/roots\",\n"
+  "    \"major/mark/main\",\n"
+  "    \"major/mark/final\",\n"
+  "    \"major/mark\",\n"
+  "    \"major/mark/global_roots_slice\",\n"
+  "    \"major_roots/global\",\n"
+  "    \"major_roots/dynamic_global\",\n"
+  "    \"major_roots/local\",\n"
+  "    \"major_roots/C\",\n"
+  "    \"major_roots/finalised\",\n"
+  "    \"major_roots/memprof\",\n"
+  "    \"major_roots/hook\",\n"
+  "    \"major/check_and_compact\",\n"
+  "    \"minor\",\n"
+  "    \"minor/local_roots\",\n"
+  "    \"minor/ref_tables\",\n"
+  "    \"minor/copy\",\n"
+  "    \"minor/update_weak\",\n"
+  "    \"minor/finalized\",\n"
+  "    \"explicit/gc_major_slice\"\n"
+  "};\n\n"
+  ""
+  "/*\n\n"
+  ""
+  "Miscellaneous GC counters\n\n"
+  ""
+  "*/\n"
+  "enum gc_counter : uint16_t {\n"
+  "    \"alloc_jump\",\n"
+  "    \"force_minor/alloc_small\",\n"
+  "    \"force_minor/make_vect\",\n"
+  "    \"force_minor/set_minor_heap_size\",\n"
+  "    \"force_minor/weak\",\n"
+  "    \"force_minor/memprof\",\n"
+  "    \"major/mark/slice/remain\",\n"
+  "    \"major/mark/slice/fields\",\n"
+  "    \"major/mark/slice/pointers\",\n"
+  "    \"major/work/extra\",\n"
+  "    \"major/work/mark\",\n"
+  "    \"major/work/sweep\",\n"
+  "    \"minor/promoted\",\n"
+  "    \"request_major/alloc_shr\",\n"
+  "    \"request_major/adjust_gc_speed\",\n"
+  "    \"request_minor/realloc_ref_table\",\n"
+  "    \"request_minor/realloc_ephe_ref_table\",\n"
+  "    \"request_minor/realloc_custom_table\"\n"
+  "};\n\n"
+  ""
+  "/*\n\n"
+  ""
+  "Block allocation counters, per size buckets.\n\n"
+  ""
+  "*/\n"
+  "enum alloc_bucket : uint8_t {\n"
+  "  \"alloc 01\" = 1,\n"
+  "  \"alloc 02\",\n"
+  "  \"alloc 03\",\n"
+  "  \"alloc 04\",\n"
+  "  \"alloc 05\",\n"
+  "  \"alloc 06\",\n"
+  "  \"alloc 07\",\n"
+  "  \"alloc 08\",\n"
+  "  \"alloc 09\",\n"
+  "  \"alloc 10-19\",\n"
+  "  \"alloc 20-29\",\n"
+  "  \"alloc 30-39\",\n"
+  "  \"alloc 40-49\",\n"
+  "  \"alloc 50-59\",\n"
+  "  \"alloc 60-69\",\n"
+  "  \"alloc 70-79\",\n"
+  "  \"alloc 80-89\",\n"
+  "  \"alloc 90-99\",\n"
+  "  \"alloc large\"\n"
+  "};\n\n"
+  ""
+  "/*\n\n"
+  ""
+  "Each event is comprised of the previously defined event.header\n"
+  "and the fields defined here.\n\n"
+  ""
+  "An entry event marks the start of a gc phase.\n\n"
+  ""
+  "*/\n"
+  "event {\n"
+  "    id = 0;\n"
+  "    name = \"entry\";\n"
+  "    stream_id = 0;\n"
+  "    fields := struct {\n"
+  "        enum gc_phase phase;\n"
+  "    };\n"
+  "};\n\n"
+  ""
+  "/*\n\n"
+  ""
+  "exit counterparts to entry events\n\n"
+  ""
+  "*/\n"
+  "event {\n"
+  "    id = 1;\n"
+  "    name = \"exit\";\n"
+  "    stream_id = 0;\n"
+  "    fields := struct {\n"
+  "        enum gc_phase phase;\n"
+  "    };\n"
+  "};\n\n"
+  ""
+  "event {\n"
+  "    id = 2;\n"
+  "    name = \"counter\";\n"
+  "    stream_id = 0;\n"
+  "    fields := struct {\n"
+  "        uint64_t count;\n"
+  "        enum gc_counter kind;\n"
+  "    };\n"
+  "};\n\n"
+  ""
+  "event {\n"
+  "    id = 3;\n"
+  "    name = \"alloc\";\n"
+  "    stream_id = 0;\n"
+  "    fields := struct {\n"
+  "        uint64_t count;\n"
+  "        enum alloc_bucket bucket;\n"
+  "    };\n"
+  "};\n\n"
+  ""
+  "/*\n"
+  " Flush events are used to track the time spent by the tracing runtime flushing\n"
+  " data to disk, useful to remove flushing overhead for other runtime mesurements\n"
+  " in the trace.\n"
+  "*/\n"
+  "event {\n"
+  "     id = 4;\n"
+  "     name = \"flush\";\n"
+  "     stream_id = 0;\n"
+  "     fields := struct {\n"
+  "        uint64_t duration;\n"
+  "     };\n"
+  "};\n";
 /* Description of a user event for the 'metadata' stream */
-const char_os *user_event_format = "\nevent {\n     id = %d;\n     name = \"%s\";\n     stream_id = 0;\n     fields := struct {\n        uint8_t span_type;\n     };\n};\n";
+const char_os *user_event_format = "\n"
+  "event {\n"
+  "     id = %d;\n"
+  "     name = \"%s\";\n"
+  "     stream_id = 0;\n"
+  "     fields := struct {\n"
+  "        uint8_t span_type;\n"
+  "     };\n"
+  "};\n";
 static struct ctf_metadata_header metadata_header = {
   CTF_METADATA_MAGIC,
   CTF_TRACE_UUID,
@@ -110,11 +336,10 @@ are used in the code but not directly emitted as is to the trace files. */
 
 struct event {
   struct ctf_event_header header;
-  uint16_t  phase; /* for GC events */
-  uint16_t  counter_kind; /* misc counter name */
-  uint8_t  alloc_bucket; /* for alloc counters */
+  uint16_t span_type; /* for span events */
+  uint16_t counter_kind; /* misc counter name */
+  uint8_t alloc_bucket; /* for alloc counters */
   uint64_t count; /* for misc counters */
-  uint8_t span_type; /* for user events */
 };
 
 #define EVENT_BUF_SIZE 4096
@@ -279,10 +504,10 @@ static void flush_events(FILE* out, struct event_buffer* eb)
     switch (ev.header.id)
     {
     case EV_ENTRY:
-      FWRITE_EV(&ev.phase, sizeof(uint16_t));
+      FWRITE_EV(&ev.span_type, sizeof(uint16_t));
       break;
     case EV_EXIT:
-      FWRITE_EV(&ev.phase, sizeof(uint16_t));
+      FWRITE_EV(&ev.span_type, sizeof(uint16_t));
       break;
     case EV_COUNTER:
       FWRITE_EV(&ev.count, sizeof(uint64_t));
@@ -361,8 +586,8 @@ void caml_eventlog_init()
   atexit(&teardown_eventlog);
 }
 
-static void post_event(ev_gc_phase phase, ev_gc_counter counter_kind,
-                       uint8_t bucket, uint64_t count, ev_user_type span_type, ev_type ty)
+static void post_event(ev_span_type span_type, ev_gc_counter counter_kind,
+                       uint8_t bucket, uint64_t count, ev_type ty)
 {
   uintnat i;
   struct event* ev;
@@ -379,29 +604,28 @@ static void post_event(ev_gc_phase phase, ev_gc_counter counter_kind,
   }
   ev = &evbuf->events[i];
   ev->header.id = ty;
+  ev->span_type = span_type;
   ev->count = count;
   ev->counter_kind = counter_kind;
   ev->alloc_bucket = bucket;
-  ev->phase = phase;
-  ev->span_type = span_type;
   ev->header.timestamp = time_counter() -
                            Caml_state->eventlog_startup_timestamp;
   evbuf->ev_generated = i + 1;
 }
 
-void caml_ev_begin(ev_gc_phase phase)
+void caml_ev_begin(ev_span_type span_type)
 {
-  post_event(phase, 0, 0, 0, 0, EV_ENTRY);
+  post_event(span_type, 0, 0, 0, EV_ENTRY);
 }
 
-void caml_ev_end(ev_gc_phase phase)
+void caml_ev_end(ev_span_type span_type)
 {
-  post_event(phase, 0, 0, 0, 0, EV_EXIT);
+  post_event(span_type, 0, 0, 0, EV_EXIT);
 }
 
 void caml_ev_counter(ev_gc_counter counter, uint64_t val)
 {
-  post_event(0, counter, 0, val, 0, EV_COUNTER);
+  post_event(0, counter, 0, val, EV_COUNTER);
 }
 
 static uint64_t alloc_buckets [20] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
@@ -437,7 +661,7 @@ void caml_ev_alloc_flush()
 
   for (i = 1; i < 20; i++) {
     if (alloc_buckets[i] != 0) {
-      post_event(0, 0, i, alloc_buckets[i], 0, EV_ALLOC);
+      post_event(0, 0, i, alloc_buckets[i], EV_ALLOC);
     };
     alloc_buckets[i] = 0;
   }
@@ -520,14 +744,14 @@ CAMLprim value caml_eventlog_new_event(value v)
 CAMLprim value caml_eventlog_emit_begin_event(value v)
 {
   int cur_event_id = Int_val(v);
-  post_event(0, 0, 0, 0, EV_USER_BEGIN, cur_event_id);
+  post_event(EV_USER_BEGIN, 0, 0, 0, cur_event_id);
   return Val_unit;
 }
 
 CAMLprim value caml_eventlog_emit_end_event(value v)
 {
   int cur_event_id = Int_val(v);
-  post_event(0, 0, 0, 0, EV_USER_END, cur_event_id);
+  post_event(EV_USER_END, 0, 0, 0, cur_event_id);
   return Val_unit;
 }
 

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -123,8 +123,18 @@ let delete_alarm a = a := false
 
 type event = int
 external new_event : string -> event = "caml_eventlog_new_event"
-external emit_begin_event : event -> unit = "caml_eventlog_emit_begin_event"
-external emit_end_event : event -> unit = "caml_eventlog_emit_end_event"
+external post_begin_event : event -> bool -> int -> unit = "caml_eventlog_post_begin_event"
+external post_end_event : event -> bool -> int -> unit = "caml_eventlog_post_end_event"
+
+let emit_begin_event ?tid cur_event =
+  match tid with
+  | None -> post_begin_event cur_event false 0
+  | Some id -> post_begin_event cur_event true id
+
+let emit_end_event ?tid cur_event =
+  match tid with
+  | None -> post_end_event cur_event false 0
+  | Some id -> post_end_event cur_event true id
 
 module Memprof =
   struct

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -121,6 +121,11 @@ let create_alarm f =
 
 let delete_alarm a = a := false
 
+type event = int
+external new_event : string -> event = "caml_eventlog_new_event"
+external emit_begin_event : event -> unit = "caml_eventlog_emit_begin_event"
+external emit_end_event : event -> unit = "caml_eventlog_emit_end_event"
+
 module Memprof =
   struct
     type allocation =

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -441,11 +441,11 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
 
 type event
 
-external new_event : string -> event = "caml_eventlog_new_event"
+val new_event : string -> event
 
-external emit_begin_event : event -> unit = "caml_eventlog_emit_begin_event"
+val emit_begin_event : event -> unit
 
-external emit_end_event : event -> unit = "caml_eventlog_emit_end_event"
+val emit_end_event : event -> unit
 
 (** [Memprof] is a sampling engine for allocated memory words. Every
    allocated word has a probability of being sampled equal to a

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -443,9 +443,9 @@ type event
 
 val new_event : string -> event
 
-val emit_begin_event : event -> unit
+val emit_begin_event : ?tid:int -> event -> unit
 
-val emit_end_event : event -> unit
+val emit_end_event : ?tid:int -> event -> unit
 
 (** [Memprof] is a sampling engine for allocated memory words. Every
    allocated word has a probability of being sampled equal to a

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -439,6 +439,13 @@ external eventlog_resume : unit -> unit = "caml_eventlog_resume"
    was started with OCAML_EVENTLOG_ENABLED=p. (which pauses the collection of
    traces before the first event.) *)
 
+type event
+
+external new_event : string -> event = "caml_eventlog_new_event"
+
+external emit_begin_event : event -> unit = "caml_eventlog_emit_begin_event"
+
+external emit_end_event : event -> unit = "caml_eventlog_emit_end_event"
 
 (** [Memprof] is a sampling engine for allocated memory words. Every
    allocated word has a probability of being sampled equal to a


### PR DESCRIPTION
**Motivation**

Currently the instrumented runtime provides a mechanism for users to obtain a profile of all the GC events that took place during the execution of a program, and to be able to easily visualize this information in the Chrome tracing interface. However, there are scenarios when we want to profile not just the GC but certain pieces of user code as well. Furthermore, in cases like tail latency debugging, obtaining aggregate statistics isn't enough; what is desired is the ability to pinpoint where things went wrong and what exactly was going on when this misfortune befell our execution.

Keeping these goals in mind, this PR extends the incumbent CTF tracing architecture by providing an external API for users to instrument arbitrary spans of user code. In particular, the API allows users to instantiate new span user events through the instrumented runtime and to emit the beginning and ending of the occurrence of these events. The trace output is still consistent with the CTF output and allows the user events and GC events to be visualized in the same user interface (currently the Chrome tracing interface).

Throughout development, we used an http/af [webserver](https://github.com/gshag/httpaf_webserver/blob/master/httpaf_server.ml) as our motivating example since it displayed a sharp rise in its tail latency and we wished to be able to tackle the problem of debugging this phenomenon using our new API. Even though we ended up facing significant challenges due to the callback-oriented nature of Async, one key learning we obtained was that sometimes we want multiple events to be 'linked' to each other, as is the case when execution happens asynchronously. To enable this, we modified our API so that on emission of events, users can specify an optional identifier in the form of a thread ID. This will allow different events to be displayed together in the Chrome tracing interface while allowing for the existence of overlapping events of the same name, since events from each thread get displayed separately.

**The API**

As found in the `gc.mli` file, the external API is as follows:

```
type event

val new_event : string -> event

val emit_begin_event : ?tid:int -> event -> unit

val emit_end_event : ?tid:int -> event -> unit
```

The `new_event` function allows for the creation of a new type of user `event` using a string identifier (name). That `event` can then be emitted as a span event an arbitrary number of times using `emit_begin_event` and `emit_end_event`. As mentioned above, each of these functions takes an optional `tid` argument. If it is not provided, then the thread ID for these events is set to the process ID.

**Performance**

To gauge the effect of the new API on performance, we ran some benchmarks. In particular, we ran the http/af webserver and measured its latency profile using [wrk2](https://github.com/giltene/wrk2) in 4 different scenarios.

1. By running the webserver through the 'normal' runtime (without the instrumented runtime flags) on 4.11.0+beta2 (labelled as 'Normal runtime' below).
2. By running the webserver through the instrumented runtime present on 4.11.0+beta2 ('GC events').
3. By running the webserver under the version of the compiler with these changes, i.e. with the user events API.
    - Instrumenting only the [request handler](https://github.com/inhabitedtype/httpaf/blob/a783ec01ec7e31f4d5e9cb833b890b7f5b94f169/examples/lib/httpaf_examples.ml#L68-L73) in the httpaf library by straddling its execution across a `request` user event ('Request events').
    - Instrumenting the request handler as well as the [reader](https://github.com/inhabitedtype/httpaf/blob/227220d24b7cd68b664a1e8cf4c489269e71d4aa/async/httpaf_async.ml#L103-L126) and [writer](https://github.com/inhabitedtype/httpaf/blob/227220d24b7cd68b664a1e8cf4c489269e71d4aa/async/httpaf_async.ml#L130-L143) threads in the httpaf library, each with its own type of user event for a total of 3 types of user events ('Three user events').

The specific `wrk2` command that was used was: ```./wrk -d30 -c10k -R30k -t2 -L http://127.0.0.1:8080```. To quote the `wrk2` documentation, that runs a benchmark for 30 seconds, using 2 threads, keeping 10k HTTP connections open, and a constant throughput of 30k requests per second (total, across all connections combined). 

The findings are summarized by the graph below. The performance overhead of the user events API as well as the incumbent instrumented runtime seems to be fairly reasonable for the advantages they each offer.

<p align="center">
<img src="https://github.com/gshag/ctf-to-catapult/blob/master/trace_graph.png?raw=true" width=70% height=70%>
</p>

**Addendum**

Quick summary of code changes:

- The CTF metadata stream needs to be dynamically extendible for arbitrary user events. To do so, the previously plaintext metadata stream has been converted to a packet-based stream and appropriate event descriptions are appended to it on invocations of `Gc.new_event`.
- Addition of a few functions in the GC module implemented in `eventlog.c` that serve as the external API for this change.
- Emission of user events upon invocation of `Gc.emit_begin_event` and `Gc.emit_end_event`.
- A few changes to the metadata format found [here](https://github.com/ocaml/ocaml/blob/trunk/tools/eventlog_metadata.in) in order to make the new metadata stream compatible with babeltrace2 for visualization of the events. This includes moving the PID to the packet context and adding a TID field to the event context.
- A Python helper script to convert the CTF output of running the instrumented runtime to the catapult format, which can be found [here](https://github.com/gshag/ctf-to-catapult).